### PR TITLE
fix: use PROGMEM macro

### DIFF
--- a/src/bip39.cpp
+++ b/src/bip39.cpp
@@ -17,20 +17,6 @@
 #include <functional>
 #include <cassert>
 
-// Some platforms handle PROGMEM differently.
-// This macro resolves "pointer-to-object" errors in those platforms.
-// src: https://github.com/SlashDevin/NeoGPS/issues/112
-#if defined(ESP8266) |              \
-    defined(ARDUINO_SAMD_MKRZERO) | \
-    defined(ARDUINO_SAMD_ZERO) |    \
-    defined(ARDUINO_SAM_DUE) |      \
-    defined(ARDUINO_ARCH_ARC32) |   \
-    defined(__TC27XX__) |           \
-    (defined(TEENSYDUINO) && (TEENSYDUINO < 139))
-#undef pgm_read_ptr
-#define pgm_read_ptr(addr) (*(const void **)(addr))
-#endif
-
 namespace BIP39 {
 
 using random_bytes_engine = std::independent_bits_engine<

--- a/src/bip39.cpp
+++ b/src/bip39.cpp
@@ -17,6 +17,20 @@
 #include <functional>
 #include <cassert>
 
+// Some platforms handle PROGMEM differently.
+// This macro resolves "pointer-to-object" errors in those platforms.
+// src: https://github.com/SlashDevin/NeoGPS/issues/112
+#if defined(ESP8266) |              \
+    defined(ARDUINO_SAMD_MKRZERO) | \
+    defined(ARDUINO_SAMD_ZERO) |    \
+    defined(ARDUINO_SAM_DUE) |      \
+    defined(ARDUINO_ARCH_ARC32) |   \
+    defined(__TC27XX__) |           \
+    (defined(TEENSYDUINO) && (TEENSYDUINO < 139))
+#undef pgm_read_ptr
+#define pgm_read_ptr(addr) (*(const void **)(addr))
+#endif
+
 namespace BIP39 {
 
 using random_bytes_engine = std::independent_bits_engine<

--- a/src/util.h
+++ b/src/util.h
@@ -32,6 +32,20 @@
 
 #endif
 
+// Some platforms handle PROGMEM differently.
+// This macro resolves "pointer-to-object" errors in those platforms.
+// src: https://github.com/SlashDevin/NeoGPS/issues/112
+#if defined(ESP8266) |              \
+    defined(ARDUINO_SAMD_MKRZERO) | \
+    defined(ARDUINO_SAMD_ZERO) |    \
+    defined(ARDUINO_SAM_DUE) |      \
+    defined(ARDUINO_ARCH_ARC32) |   \
+    defined(__TC27XX__) |           \
+    (defined(TEENSYDUINO) && (TEENSYDUINO < 139))
+#undef pgm_read_ptr
+#define pgm_read_ptr(addr) (*(const void **)(addr))
+#endif
+
 namespace BIP39 {
 
 word_list split(const std::string& s, char delimiter);


### PR DESCRIPTION
Some platforms now throw the error: `'const void*' is not a pointer-to-object type` with PIO in Linux.
It appears they handle PROGMEM differently.
This PR adds a macro resolves "pointer-to-object" errors in those platforms.

---

PGM Macro:

```cpp
#if defined(ESP8266) |              \
    defined(ARDUINO_SAMD_MKRZERO) | \
    defined(ARDUINO_SAMD_ZERO) |    \
    defined(ARDUINO_SAM_DUE) |      \
    defined(ARDUINO_ARCH_ARC32) |   \
    defined(__TC27XX__) |           \
    (defined(TEENSYDUINO) && (TEENSYDUINO < 139))
#undef pgm_read_ptr
#define pgm_read_ptr(addr) (*(const void **)(addr))
#endif
```
>src: https://github.com/SlashDevin/NeoGPS/issues/112

---

Example Build Error:
```
In file included from /home/circleci/.platformio/packages/framework-arduinoespressif8266/tools/sdk/libc/xtensa-lx106-elf/include/string.h:163:0,
from /home/circleci/.platformio/packages/framework-arduinoespressif8266/cores/esp8266/Arduino.h:33,
from .piolibdeps/bip39_ID5886/src/util.h:13,
from .piolibdeps/bip39_ID5886/src/dictionary/english_str.h:4,
from .piolibdeps/bip39_ID5886/src/dictionary/english.h:4,
from .piolibdeps/bip39_ID5886/src/bip39.cpp:2:
.piolibdeps/bip39_ID5886/src/bip39.cpp: In function 'int BIP39::{anonymous}::get_word_index(const char* const*, const string&)':
.piolibdeps/bip39_ID5886/src/bip39.cpp:52:28: error: 'const void*' is not a pointer-to-object type
strcpy_P(w, (char*)pgm_read_ptr_far(&(lexicon[i]))); // NOLINT
^
/home/circleci/.platformio/packages/framework-arduinoespressif8266/tools/sdk/libc/xtensa-lx106-elf/include/sys/string.h:32:57: note: in definition of macro 'strcpy_P'
#define strcpy_P(dest, src)          strncpy_P((dest), (src), SIZE_IRRELEVANT)
^
.piolibdeps/bip39_ID5886/src/bip39.cpp: In function 'BIP39::word_list BIP39::create_mnemonic(std::vector<unsigned char>&, BIP39::language)':
.piolibdeps/bip39_ID5886/src/bip39.cpp:106:31: error: 'const void*' is not a pointer-to-object type
strcpy_P(word, (char*)pgm_read_ptr_far(&(lexicon[position]))); // NOLINT
^
/home/circleci/.platformio/packages/framework-arduinoespressif8266/tools/sdk/libc/xtensa-lx106-elf/include/sys/string.h:32:57: note: in definition of macro 'strcpy_P'
#define strcpy_P(dest, src)          strncpy_P((dest), (src), SIZE_IRRELEVANT)
^
*** [.pioenvs/esp8266/src/test/.piolibdeps/bip39_ID5886/src/bip39.cpp.o] Error 1
```